### PR TITLE
🔧 chore(gitignore): add steps directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/steps


### PR DESCRIPTION
- include /steps in .gitignore to prevent tracking build artifacts