### PR TITLE
🔧 chore(config): update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,73 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "dependencyDashboard": true,
+  "rangeStrategy": "bump",
+  "prHourlyLimit": 0,
+  "schedule": [
+    "* 0-5 24 * *"
+  ],
+  "packageRules": [
+    {
+      "groupName": "futures packages",
+      "matchPackageNames": [
+        "/^futures[-_]?/"
+      ]
+    },
+    {
+      "groupName": "serde packages",
+      "matchPackageNames": [
+        "/^serde[-_]?/"
+      ]
+    },
+    {
+      "groupName": "tokio packages",
+      "matchPackageNames": [
+        "/^tokio[-_]?/"
+      ]
+    },
+    {
+      "groupName": "tracing packages",
+      "matchPackageNames": [
+        "/^tracing[-_]?/",
+        "!tracing-opentelemetry"
+      ]
+    },
+    {
+      "groupName": "liquid packages",
+      "matchPackageNames": [
+        "/^liquid[-_]?/",
+        "/^kstring$/"
+      ]
+    },
+    {
+      "automerge": true,
+      "matchPackageNames": [
+        "/github/codeql-action/",
+        "/ossf/scorecard-action/",
+        "/actions/upload-artifact/",
+        "/actions/checkout/"
+      ]
+    },
+    {
+      "sourceUrl": "https://github.com/jerus-org/circleci-toolkit",
+      "enabled": true,
+      "matchPackageNames": [
+        "/jerus-org/circleci-toolkit/"
+      ]
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^rust-toolchain\\.toml?$"
+      ],
+      "matchStrings": [
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
+      ],
+      "depNameTemplate": "rust",
+      "packageNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-releases"
+    }
   ]
 }


### PR DESCRIPTION
- enable dependency dashboard for better visibility
- set range strategy to "bump" for version updates
- add schedule for renovation runs during off-peak hours
- group packages by common prefixes for organized updates
- enable automerge for specific GitHub action packages
- configure custom manager for rust-toolchain updates