### PR TITLE
feat: add release-hook.sh script for automated changelog generation

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add release-hook.sh script for automated changelog generation(pr [#108])
+
 ### Changed
 
 - chore-rename CHANGELOG.md to PRLOG.md(pr [#106])
@@ -346,6 +350,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#105]: https://github.com/jerus-org/wpsr/pull/105
 [#106]: https://github.com/jerus-org/wpsr/pull/106
 [#107]: https://github.com/jerus-org/wpsr/pull/107
+[#108]: https://github.com/jerus-org/wpsr/pull/108
 [Unreleased]: https://github.com/jerus-org/wpsr/compare/v0.2.3...HEAD
 [0.2.3]: https://github.com/jerus-org/wpsr/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/jerus-org/wpsr/compare/v0.2.1...v0.2.2

--- a/release-hook.sh
+++ b/release-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Build Changelog
+gen-changelog generate --display-summaries --next-version "$SEMVER"


### PR DESCRIPTION
This PR adds a release-hook.sh script to enable automated changelog generation during the release process.

## Changes
- Added release-hook.sh script (executable)
- Script integrates with release tooling to generate changelog entries

## Purpose
This script will be automatically executed during the release process to generate changelog entries using the gen-changelog tool and update the PRLOG.md file with version-specific information.